### PR TITLE
Example singleuser z2jh config

### DIFF
--- a/jupyter-guacamole/Dockerfile
+++ b/jupyter-guacamole/Dockerfile
@@ -16,7 +16,11 @@ ENV JETTY_HOME=/opt/jetty-home-10.0.14
 
 RUN python3 -mpip install jhsingle-native-proxy==0.8.0
 
-RUN useradd --system --create-home --shell /usr/sbin/nologin guacamole
+# Use 1000:1000 to match the default Jupyter user
+ARG UID=1000
+ARG GID=1000
+RUN groupadd --gid $GID guacamole
+RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --gid $GID guacamole
 WORKDIR /home/guacamole
 
 ARG GUACAMOLE_JUPYTER_VERSION=1.5.0

--- a/ubuntu-mate-vnc/Dockerfile
+++ b/ubuntu-mate-vnc/Dockerfile
@@ -22,29 +22,40 @@ RUN apt-get update -y -q && \
     apt-get purge -y -q mate-screensaver && \
     apt-get autoremove -y -q
 
-RUN useradd -m ubuntu -s /usr/bin/bash
+RUN useradd -m ubuntu -s /usr/bin/bash && \
+    mkdir -p /opt/conda/Desktop /opt/conda/icons && \
+    chown -R ubuntu:ubuntu /opt/conda
 
 USER ubuntu
 WORKDIR /home/ubuntu
 
 ARG MAMBAFORGE_VERSION=22.11.1-4
 RUN curl -sfL https://github.com/conda-forge/miniforge/releases/download/$MAMBAFORGE_VERSION/Mambaforge-$MAMBAFORGE_VERSION-Linux-`uname -m`.sh -o Mambaforge.sh && \
-    bash Mambaforge.sh -b -f -p ~/conda && \
+    bash Mambaforge.sh -b -f -p /opt/conda && \
     rm -f Mambaforge.sh
-COPY --chown=ubuntu:ubuntu environment.yml /home/ubuntu/environment.yml
-RUN ~/conda/bin/mamba init && \
-    ~/conda/bin/mamba env update --file /home/ubuntu/environment.yml
+COPY --chown=ubuntu:ubuntu environment.yml /opt/conda/environment.yml
+RUN /opt/conda/bin/mamba init && \
+    /opt/conda/bin/mamba env update --file /opt/conda/environment.yml
+
+COPY --chown=ubuntu:ubuntu jupyter_logo.svg /opt/conda/icons/jupyter_logo.svg
+COPY --chown=ubuntu:ubuntu jupyterlab.desktop /opt/conda/Desktop/jupyterlab.desktop
 
 RUN mkdir /home/ubuntu/Desktop && \
-    ln -s /usr/share/applications/mate-terminal.desktop /home/ubuntu/Desktop/mate-terminal.desktop && \
-    ln -s /usr/share/applications/firefox.desktop /home/ubuntu/Desktop/firefox.desktop
+    ln -s \
+        /usr/share/applications/mate-terminal.desktop \
+        /usr/share/applications/firefox.desktop \
+        /opt/conda/Desktop/jupyterlab.desktop \
+        /home/ubuntu/Desktop
 
-COPY --chown=ubuntu:ubuntu jupyter_logo.svg /home/ubuntu/.icons/jupyter_logo.svg
-COPY --chown=ubuntu:ubuntu jupyterlab.desktop /home/ubuntu/Desktop/jupyterlab.desktop
+USER root
+# /home/ubuntu may be overwritten with a persistent volume
+# Create a copy and restore on first start if necessary
+RUN rsync -a /home/ubuntu/ /home/ubuntu.orig/
 
 COPY start-mate.sh /usr/local/bin/start-mate.sh
 COPY start.sh /usr/local/bin/start.sh
 
+USER ubuntu
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 EXPOSE 5901

--- a/ubuntu-mate-vnc/jupyterlab.desktop
+++ b/ubuntu-mate-vnc/jupyterlab.desktop
@@ -3,6 +3,6 @@
 Version=1.0
 Type=Application
 Terminal=true
-Icon=/home/ubuntu/.icons/jupyter_logo.svg
-Exec=/home/ubuntu/conda/bin/jupyter-lab
+Icon=/opt/conda/icons/jupyter_logo.svg
+Exec=/opt/conda/bin/jupyter-lab
 Name=JupyterLab

--- a/ubuntu-mate-vnc/start.sh
+++ b/ubuntu-mate-vnc/start.sh
@@ -12,4 +12,9 @@ else
   exit 1
 fi
 
+if [ ! -d /home/ubuntu/Desktop ]; then
+  echo "First run, setting up ubuntu"
+  rsync /home/ubuntu.orig/ -av --ignore-existing /home/ubuntu/
+fi
+
 /usr/bin/tigervncserver :1 -fg $LOCALHOST_ARGS -SecurityTypes None -xstartup /usr/local/bin/start-mate.sh

--- a/z2jh-config.yaml
+++ b/z2jh-config.yaml
@@ -1,0 +1,38 @@
+# Example configuration for zero-to-JupyterHub
+
+singleuser:
+  image:
+    name: ghcr.io/manics/jupyter-guacamole
+    tag: main
+  storage:
+    type: none
+  # Use default entrypoint
+  cmd:
+  extraEnv:
+    GUACD_HOST: localhost
+    GUACD_PORT: "4822"
+    PROTOCOL: vnc
+    HOSTNAME: localhost
+    # Optionally disable copy out and paste in
+    # DISABLE_COPY: "true"
+    # DISABLE_PASTE: "true"
+  extraContainers:
+    - name: guacd
+      image: docker.io/guacamole/guacd:1.5.0
+    - name: ubuntu-mate
+      image: ghcr.io/manics/ubuntu-mate-vnc:main
+      env:
+        - name: LOCALHOST
+          value: "yes"
+  # startTimeout: 300
+  # Use the default UID from the image
+  uid:
+
+prePuller:
+  extraImages:
+    guacd:
+      name: docker.io/guacamole/guacd
+      tag: 1.5.0
+    ubuntu-mate-vnc:
+      name: ghcr.io/manics/ubuntu-mate-vnc
+      tag: main

--- a/z2jh-config.yaml
+++ b/z2jh-config.yaml
@@ -1,13 +1,30 @@
 # Example configuration for zero-to-JupyterHub
 
+hub:
+  config:
+    KubeSpawner:
+      http_timeout: 60
+  extraConfig:
+    10-modify-pod: |
+      def modify_pod_hook(spawner, pod):
+          # First container is jhproxy/guacamole, move user volume to user container
+          pod.spec.containers[1].volume_mounts = pod.spec.containers[0].volume_mounts
+          pod.spec.containers[0].volume_mounts = None
+          return pod
+      c.KubeSpawner.modify_pod_hook = modify_pod_hook
+
 singleuser:
   image:
     name: ghcr.io/manics/jupyter-guacamole
     tag: main
   storage:
-    type: none
+    # Uncomment to disable persistent storage
+    # type: none
+    homeMountPath: /home/ubuntu
   # Use default entrypoint
   cmd:
+  cloudMetadata:
+    blockWithIptables: false
   extraEnv:
     GUACD_HOST: localhost
     GUACD_PORT: "4822"
@@ -17,13 +34,10 @@ singleuser:
     # DISABLE_COPY: "true"
     # DISABLE_PASTE: "true"
   extraContainers:
-    - name: guacd
-      image: docker.io/guacamole/guacd:1.5.0
     - name: ubuntu-mate
       image: ghcr.io/manics/ubuntu-mate-vnc:main
-      env:
-        - name: LOCALHOST
-          value: "yes"
+    - name: guacd
+      image: docker.io/guacamole/guacd:1.5.0
   # startTimeout: 300
   # Use the default UID from the image
   uid:


### PR DESCRIPTION
Add an example `singleuser` Z2JH configuration for running a Ubuntu Mate desktop with Guacamole.

Modifies the Ubuntu Mate image to restore original `/home/ubuntu` if a fresh empty volume is mounted.